### PR TITLE
task(providerCleanup): Limit StationsProvider logic to handle only the stations by untroducing a new appStore. FWM-34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
                 "react-leaflet-cluster": "2.1.0",
                 "sharp": "0.32.6",
                 "tailwindcss": "3.3.3",
-                "typescript": "5.2.2"
+                "typescript": "5.2.2",
+                "zustand": "4.5.0"
             },
             "devDependencies": {
                 "@types/leaflet": "1.9.4",
@@ -7405,6 +7406,14 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/use-sync-external-store": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7689,6 +7698,33 @@
             "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zustand": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.0.tgz",
+            "integrity": "sha512-zlVFqS5TQ21nwijjhJlx4f9iGrXSL0o/+Dpy4txAP22miJ8Ti6c1Ol1RLNN98BMib83lmDH/2KmLwaNXpjrO1A==",
+            "dependencies": {
+                "use-sync-external-store": "1.2.0"
+            },
+            "engines": {
+                "node": ">=12.7.0"
+            },
+            "peerDependencies": {
+                "@types/react": ">=16.8",
+                "immer": ">=9.0.6",
+                "react": ">=16.8"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "immer": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                }
             }
         }
     },
@@ -12841,6 +12877,12 @@
                 "punycode": "^2.1.0"
             }
         },
+        "use-sync-external-store": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+            "requires": {}
+        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -13049,6 +13091,14 @@
             "version": "3.21.4",
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
             "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
+        },
+        "zustand": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.0.tgz",
+            "integrity": "sha512-zlVFqS5TQ21nwijjhJlx4f9iGrXSL0o/+Dpy4txAP22miJ8Ti6c1Ol1RLNN98BMib83lmDH/2KmLwaNXpjrO1A==",
+            "requires": {
+                "use-sync-external-store": "1.2.0"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
         "react-leaflet-cluster": "2.1.0",
         "sharp": "0.32.6",
         "tailwindcss": "3.3.3",
-        "typescript": "5.2.2"
+        "typescript": "5.2.2",
+        "zustand": "4.5.0"
     },
     "devDependencies": {
         "@types/leaflet": "1.9.4",

--- a/src/components/BaseComponents/BaseModal.tsx
+++ b/src/components/BaseComponents/BaseModal.tsx
@@ -1,26 +1,25 @@
 "use client";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, ReactNode } from "react";
-import { useStationsProvider } from "@/providers/StationsProvider";
 import CommonButton from "@/components/Common/CommonButton";
 import { XCircleIcon } from "@heroicons/react/24/solid";
+import { useAppStore } from "@/hooks/useAppStore";
 
 type BaseModalProps = {
-    isOpen: boolean;
     children: ReactNode;
 };
 
-export default function BaseModal({ children, isOpen }: Readonly<BaseModalProps>) {
-    const stationsProvider = useStationsProvider();
-    const closeModal = () => stationsProvider.handleModal(false);
+export default function BaseModal({ children }: Readonly<BaseModalProps>) {
+    const { isStationModalOpen, setIsStationModalOpen, setActiveStation } = useAppStore();
+    const closeModal = () => {
+        setIsStationModalOpen(false);
+        setActiveStation(0);
+    };
+
     return (
-        <Transition 
-            appear 
-            show={isOpen} 
-            as={Fragment}
-        >
-            <Dialog 
-                open={isOpen}
+        <Transition appear show={isStationModalOpen} as={Fragment}>
+            <Dialog
+                open={isStationModalOpen}
                 onClose={closeModal}
                 as="div"
                 className="relative z-10"

--- a/src/components/Home/HomepageMap.tsx
+++ b/src/components/Home/HomepageMap.tsx
@@ -1,29 +1,23 @@
 import dynamic from "next/dynamic";
-import { useMemo, useState } from "react";
 import { useStationsProvider } from "@/providers/StationsProvider";
 import L, { MarkerCluster } from "leaflet";
 import { CONFIG } from "@/common/mapSettings";
 import { MarkerCustomAttrs } from "@/types/customMarker";
 import { assetUrl } from "@/common/assetsHandling";
 
+import { useAppStore } from "@/hooks/useAppStore";
 import BaseModal from "@/components/BaseComponents/BaseModal";
 import StationModalContent from "@/components/Home/StationModalContent";
 import MapControls from "@/components/MapControls/MapControls";
 const BaseMap = dynamic(() => import("@/components/BaseComponents/BaseMap"), {
     ssr: false,
 });
-const BaseMarker = dynamic(
-    () => import("@/components/BaseComponents/BaseMarker"),
-    {
-        ssr: false,
-    }
-);
-const MarkerClusterGroup = dynamic(
-    () => import("react-leaflet-cluster"),
-    {
-        ssr: false,
-    }
-);
+const BaseMarker = dynamic(() => import("@/components/BaseComponents/BaseMarker"), {
+    ssr: false,
+});
+const MarkerClusterGroup = dynamic(() => import("react-leaflet-cluster"), {
+    ssr: false,
+});
 
 export default function HomepageMap() {
     const zoomLevel = CONFIG.default_zoom_level;
@@ -32,21 +26,20 @@ export default function HomepageMap() {
     const minZoom = CONFIG.minZoom;
 
     // Create the state for the modal info
-    const [activeStation, setActiveStation] = useState(0);
-    const [markers, setMarkers] = useState<any>([]);
-    const stationsProvider = useStationsProvider();
+    const { setIsStationModalOpen, setActiveStation } = useAppStore();
+    const { stations } = useStationsProvider();
+
     const handleModal = (value: boolean, stationId: number) => {
-        stationsProvider.handleModal(value);
+        setIsStationModalOpen(value);
         setActiveStation(stationId);
     };
-    const isModalOpen = stationsProvider.isStationModalOpen;
 
     const createClusterCustomIcon = function (cluster: MarkerCluster) {
-        const markersInCluster: L.Marker[]  = cluster.getAllChildMarkers();
+        const markersInCluster: L.Marker[] = cluster.getAllChildMarkers();
         const iconsOfCluster: string[] = [];
         markersInCluster.forEach((element) => {
             if (element.options.customAttr) {
-                const { assetId } : MarkerCustomAttrs = element.options.customAttr;
+                const { assetId }: MarkerCustomAttrs = element.options.customAttr;
                 const renderImg = assetUrl(assetId);
                 iconsOfCluster.push(renderImg);
             }
@@ -67,33 +60,21 @@ export default function HomepageMap() {
         });
     };
 
-    useMemo(() => {
-        setMarkers(
-            stationsProvider.stations.map((station) => {
-                return (
-                    <BaseMarker
-                        position={station.location.coordinates.reverse()}
-                        key={station.id}
-                        stationId={station.id}
-                        weatherDescription={
-                            station.accuweather_location
-                                .current_weather_description
-                        }
-                        assetId={station.accuweather_location.weather_condition_icon.asset}
-                        handleClick={handleModal}
-                    />
-                );
-            })
+    const markers = stations.map((station) => {
+        return (
+            <BaseMarker
+                position={station.location.coordinates.reverse()}
+                key={station.id}
+                stationId={station.id}
+                weatherDescription={station.accuweather_location.current_weather_description}
+                assetId={station.accuweather_location.weather_condition_icon.asset}
+                handleClick={handleModal}
+            />
         );
-    }, [stationsProvider.stations]);
+    });
 
     return (
-        <BaseMap
-            zoom={zoomLevel}
-            center={defaultCenter}
-            maxBounds={maxBounds}
-            minZoom={minZoom}
-        >
+        <BaseMap zoom={zoomLevel} center={defaultCenter} maxBounds={maxBounds} minZoom={minZoom}>
             <MarkerClusterGroup
                 chunkedLoading
                 iconCreateFunction={createClusterCustomIcon}
@@ -112,11 +93,8 @@ export default function HomepageMap() {
                 <MapControls />
             </div>
             <div className="absolute bottom-0">
-                <BaseModal isOpen={isModalOpen}>
-                    <StationModalContent
-                        isOpen={isModalOpen}
-                        activeStation={activeStation}
-                    ></StationModalContent>
+                <BaseModal>
+                    <StationModalContent />
                 </BaseModal>
             </div>
         </BaseMap>

--- a/src/components/Home/StationModalContent.tsx
+++ b/src/components/Home/StationModalContent.tsx
@@ -2,100 +2,43 @@
 import { useState, useEffect } from "react";
 import { DataService } from "@/services/DataService";
 import { ExportedWeatherData, WeatherData } from "@/types";
-import BaseWeatherIcon from "@/components/BaseComponents/BaseWeatherIcon";
-import { LinkIcon } from "@heroicons/react/24/solid";
-import SvgInline from "@/components/Common/SvgInline";
 import LoadingSpinner from "@/components/Common/LoadingSpinner";
-
-type StationModalContentProps = {
-    activeStation: number;
-    isOpen: boolean;
-};
-
-type literalOptions = {
-    [key: string]: string
-};
-
-/**
-* @todo Propably move these literals to some place better. Maybe i18n?
-*/
-const literals: literalOptions = {
-    cloudy: "Cloudy",
-    cold: "Cold!",
-    dreary_overcast: "Dreary overcast",
-    flurries: "Flurries",
-    fog: "Fog",
-    freezing_rain: "Freezing rain",
-    hazy_sunshine: "Hazy sunshine",
-    hot: "Hot!",
-    ice: "Icy conditions",
-    intermittent_clouds: "Intermittent clouds",
-    light_rain: "Light rain",
-    mostly_cloudy_w_flurries: "Mostly cloudy with flurries",
-    mostly_cloudy_w_showers: "Mostly cloudy with showers",
-    mostly_cloudy_w_snow: "Mostly cloudy with snow",
-    "mostly_cloudy_w_t-storms": "Mostly cloudy with thunderstorms",
-    mostly_cloudy: "Mostly cloudy",
-    mostly_sunny: "Mostly sunny",
-    partly_cloudy_w_flurries: "Partly loudy with flurries",
-    partly_cloudy_w_showers: "Partly loudy with showers",
-    "partly_cloudy_w_t-storms": "Partly loudy with thunderstorms",
-    partly_sunny: "Partly sunny",
-    rain_and_snow: "Rain & snow",
-    rain: "Rain",
-    showers: "Showers",
-    sleet: "Sleet",
-    snow: "Snow",
-    "t-storms": "Thunderstorms",
-    thunderstorm: "Thunderstorm",
-    windy: "Windy",
-    clear: "Clear night",
-    sunny: "Sunny",
-    mostly_clear: "Mostly clear",
-    hazy_moonlight: "Hazy moonlight",
-};
+import { useAppStore } from "@/hooks/useAppStore";
+import { buildExportedWeatherDataObject } from "@/utils/weatherDataFormatUtils";
+import { StationWeatherSummary } from "./StationWeatherSummary";
+import { StationWeatherDetails } from "./StationWeatherDetails";
 
 const MODAL_TIMEOUT: number = 600;
 
-export default function StationModalContent({
-    activeStation,
-    isOpen,
-}: Readonly<StationModalContentProps>) {
+const loadingBlock = (
+    <div className="absolute w-full h-full flex justify-center items-center bg-white z-[1]">
+        <LoadingSpinner />
+    </div>
+);
+
+export default function StationModalContent() {
     const dataService = new DataService();
     const [weatherData, setWeatherData] = useState<{ [key: string]: any }>([]);
     const [isLoading, setIsLoading] = useState<boolean>(true);
-
-    const buildExportedWeatherDataObject = (elem: WeatherData) => {
-        return {
-            date_created: elem.date_created,
-            temperature: elem.temperature,
-            humidity: elem.humidity,
-            barometer: elem.barometer,
-            percipitation: elem.percipitation,
-            rainrate: elem.rainrate,
-            windspd: elem.windspd,
-            winddir: elem.winddir,
-            station: elem.weather_station_id,
-            weatherDescription: elem.weather_condition,
-            assetId: elem.weather_condition_icon,
-        };
-    };
+    const { activeStation } = useAppStore();
 
     const getWeatherData = async () => {
         await dataService
             .fetchWeatherDataByStation(activeStation)
             .then((response) => {
-                const weather_data: ExportedWeatherData[] =
-                    response.data.data.map((elem: WeatherData) => {
+                const weather_data: ExportedWeatherData[] = response.data.data.map(
+                    (elem: WeatherData) => {
                         return buildExportedWeatherDataObject(elem);
-                    });
+                    }
+                );
                 return setWeatherData(weather_data);
             })
             .catch((error) => {
                 // TO-DO handle error properly
                 console.log(error);
                 return setWeatherData([]);
-            }).finally(() => {
+            })
+            .finally(() => {
                 setTimeout(() => {
                     setIsLoading(false);
                 }, MODAL_TIMEOUT);
@@ -103,141 +46,22 @@ export default function StationModalContent({
     };
 
     useEffect(() => {
-        isOpen && getWeatherData();
-    }, [isOpen]);
-    const formatDate = (inputDate: Date): string => {
-        const options: Intl.DateTimeFormatOptions = {
-            weekday: "short",
-            month: "short",
-            day: "numeric",
-            hour: "numeric",
-            minute: "numeric",
-            hour12: false,
-        };
-        const date: Date = new Date(inputDate);
-        const formattedDate: string = date.toLocaleDateString("en-US", options);
-        return formattedDate;
-    };
-    
-    const weatherConditionsText = (text: string): string => {
-        return literals[text];
-    };
+        getWeatherData();
+    }, []);
 
-    const loadingBlock = (
-        <div className="absolute w-full h-full flex justify-center items-center bg-white z-[1]">
-            <LoadingSpinner />
+    return (
+        <div>
+            {weatherData.map((elem: ExportedWeatherData) => {
+                return (
+                    <div className="p-2 flex text-black flex-col relative" key={elem.station.id}>
+                        {isLoading && loadingBlock}
+                        <div className="flex flex-col">
+                            <StationWeatherSummary {...elem} />
+                            <StationWeatherDetails {...elem} />
+                        </div>
+                    </div>
+                );
+            })}
         </div>
     );
-    const displayedData = weatherData.map((elem: ExportedWeatherData) => {
-        return (
-            <div className="p-2 flex text-black flex-col relative" key={elem.station.id}>
-                {isLoading && loadingBlock }
-                <div className="flex flex-col">
-                    <a 
-                        href={elem.station.website_url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="block mb-2"
-                    >
-                        <LinkIcon className="h-7 w-7 p-1"></LinkIcon>
-                    </a>
-                    <h2 className="text-xl font-bold">
-                        {elem.station.name}
-                        <span className="text-base font-medium">, {elem.station.prefecture_id.label}</span>
-                    </h2>
-                    <p className="text-sm opacity-60">
-                        {formatDate(elem.date_created)}
-                    </p>
-                    <div className="mt-6 flex items-center">
-                        <div className="h-24 mx-auto">
-                            <BaseWeatherIcon assetId={elem.assetId} weatherDescriptionText={elem.weatherDescription} />
-                        </div>
-                        <h3 className="text-5xl font-bold mx-auto">
-                            {elem.temperature}<sup className="font-normal text-lg ml-1">°C</sup>
-                            <small className="block text-base font-normal">
-                                {weatherConditionsText(elem.weatherDescription)}
-                            </small>
-                        </h3>
-                    </div>
-                    <div className="my-2">
-                        <h4 className="font-bold text-lg my-2">
-                            Details
-                        </h4>
-                        <div className="bg-info rounded-2xl p-4">
-                            <div className="flex items-center justify-around">
-                                <div className="flex items-center w-[100px]">
-                                    <div className="h-6 w-6">
-                                        <SvgInline
-                                            path="weather_icons/humidity.svg"
-                                            title="Humidity icon"
-                                            className="fill-white"
-                                        />
-                                    </div>
-                                    <p className="text-sm text-white leading-tight ml-2">
-                                        Humidity
-                                        <span className="block font-bold text-xs">
-                                            {elem.humidity}%
-                                        </span>
-                                    </p>
-                                </div>
-                                <div className="flex items-center w-[100px]">
-                                    <div className="h-6 w-6">
-                                        <SvgInline
-                                            path="weather_icons/barometer.svg"
-                                            className="fill-white"
-                                            title="Barometer icon"
-                                        />
-                                    </div>
-                                    <p className="text-sm text-white leading-tight ml-2">
-                                        Barometer
-                                        <span className="block font-bold text-xs">
-                                            {elem.barometer} hPa
-                                        </span>
-                                    </p>
-                                </div>
-                            </div>
-                            <div className="border-[0.5px] border-white h-[1px] my-4"></div>
-                            <div className="flex items-center justify-around">
-                                <div className="flex items-center w-[100px]">
-                                    <div className="h-4 w-6">
-                                        <SvgInline
-                                            path="weather_icons/wind.svg"
-                                            title="Wind icon"
-                                            className="fill-white"
-                                            style={{
-                                                transform: `rotate(${elem.winddir}deg)`,
-                                            }}
-                                        />
-                                    </div>
-                                    <p className="text-sm text-white leading-tight ml-2">
-                                        Wind
-                                        <span className="block font-bold text-xs">
-                                            {elem.windspd} km/h
-                                        </span>
-                                    </p>
-                                </div>
-                                <div className="flex items-center w-[100px]">
-                                    <div className="h-6 w-6">
-                                        <SvgInline
-                                            path="weather_icons/rain.svg"
-                                            title="Rain icon"
-                                            className="fill-white"
-                                        />
-                                    </div>
-                                    <p className="text-sm text-white leading-tight ml-2">
-                                        Rain
-                                        <span className="block font-bold text-xs">
-                                            {elem.percipitation} mm
-                                        </span>
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        );
-    });
-
-    return <div>{displayedData}</div>;
 }

--- a/src/components/Home/StationWeatherDetails.tsx
+++ b/src/components/Home/StationWeatherDetails.tsx
@@ -1,0 +1,72 @@
+import { ExportedWeatherData } from "@/types";
+import SvgInline from "@/components/Common/SvgInline";
+
+export function StationWeatherDetails(elem: Readonly<ExportedWeatherData>) {
+    return (
+        <div className="my-2">
+            <h4 className="font-bold text-lg my-2">Details</h4>
+            <div className="bg-info rounded-2xl p-4">
+                <div className="flex items-center justify-around">
+                    <div className="flex items-center w-[100px]">
+                        <div className="h-6 w-6">
+                            <SvgInline
+                                path="weather_icons/humidity.svg"
+                                title="Humidity icon"
+                                className="fill-white"
+                            />
+                        </div>
+                        <p className="text-sm text-white leading-tight ml-2">
+                            Humidity
+                            <span className="block font-bold text-xs">{elem.humidity}%</span>
+                        </p>
+                    </div>
+                    <div className="flex items-center w-[100px]">
+                        <div className="h-6 w-6">
+                            <SvgInline
+                                path="weather_icons/barometer.svg"
+                                className="fill-white"
+                                title="Barometer icon"
+                            />
+                        </div>
+                        <p className="text-sm text-white leading-tight ml-2">
+                            Barometer
+                            <span className="block font-bold text-xs">{elem.barometer} hPa</span>
+                        </p>
+                    </div>
+                </div>
+                <div className="border-[0.5px] border-white h-[1px] my-4"></div>
+                <div className="flex items-center justify-around">
+                    <div className="flex items-center w-[100px]">
+                        <div className="h-4 w-6">
+                            <SvgInline
+                                path="weather_icons/wind.svg"
+                                title="Wind icon"
+                                className="fill-white"
+                                style={{
+                                    transform: `rotate(${elem.winddir}deg)`,
+                                }}
+                            />
+                        </div>
+                        <p className="text-sm text-white leading-tight ml-2">
+                            Wind
+                            <span className="block font-bold text-xs">{elem.windspd} km/h</span>
+                        </p>
+                    </div>
+                    <div className="flex items-center w-[100px]">
+                        <div className="h-6 w-6">
+                            <SvgInline
+                                path="weather_icons/rain.svg"
+                                title="Rain icon"
+                                className="fill-white"
+                            />
+                        </div>
+                        <p className="text-sm text-white leading-tight ml-2">
+                            Rain
+                            <span className="block font-bold text-xs">{elem.percipitation} mm</span>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/Home/StationWeatherSummary.tsx
+++ b/src/components/Home/StationWeatherSummary.tsx
@@ -1,0 +1,39 @@
+import { ExportedWeatherData } from "@/types";
+import { LinkIcon } from "@heroicons/react/24/solid";
+import BaseWeatherIcon from "../BaseComponents/BaseWeatherIcon";
+import { formatDate, weatherConditionsText } from "@/utils/weatherDataFormatUtils";
+
+export function StationWeatherSummary(elem: Readonly<ExportedWeatherData>) {
+    return (
+        <>
+            <a
+                href={elem.station.website_url}
+                target="_blank"
+                rel="noreferrer"
+                className="block mb-2"
+            >
+                <LinkIcon className="h-7 w-7 p-1"></LinkIcon>
+            </a>
+            <h2 className="text-xl font-bold">
+                {elem.station.name}
+                <span className="text-base font-medium">, {elem.station.prefecture_id.label}</span>
+            </h2>
+            <p className="text-sm opacity-60">{formatDate(elem.date_created)}</p>
+            <div className="mt-6 flex items-center">
+                <div className="h-24 mx-auto">
+                    <BaseWeatherIcon
+                        assetId={elem.assetId}
+                        weatherDescriptionText={elem.weatherDescription}
+                    />
+                </div>
+                <h3 className="text-5xl font-bold mx-auto">
+                    {elem.temperature}
+                    <sup className="font-normal text-lg ml-1">°C</sup>
+                    <small className="block text-base font-normal">
+                        {weatherConditionsText(elem.weatherDescription)}
+                    </small>
+                </h3>
+            </div>
+        </>
+    );
+}

--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+
+type AppStore = {
+    isStationModalOpen: boolean;
+    setIsStationModalOpen: (value: boolean) => void;
+    activeStation: number;
+    setActiveStation: (stationId: number) => void;
+};
+
+export const useAppStore = create<AppStore>((set) => ({
+    isStationModalOpen: false,
+    setIsStationModalOpen: (isStationModalOpen) => {
+        set(() => ({ isStationModalOpen }));
+    },
+    activeStation: 0,
+    setActiveStation: (activeStation) => {
+        set(() => ({ activeStation }));
+    },
+}));

--- a/src/providers/StationsProvider.tsx
+++ b/src/providers/StationsProvider.tsx
@@ -1,24 +1,13 @@
 "use client";
-import {
-    ReactElement,
-    useContext,
-    useMemo,
-    useEffect,
-    useState,
-    createContext
-} from "react";
+import { ReactElement, useContext, createContext, useMemo, useState, useEffect } from "react";
 import { DataService } from "@/services/DataService";
 
 interface CurrentStationContextType {
     stations: any[];
-    isStationModalOpen: boolean;
-    handleModal: (isStationModalOpen: boolean) => void;
 }
 
 const StationsContext = createContext<CurrentStationContextType>({
     stations: [],
-    isStationModalOpen: false,
-    handleModal: () => null,
 });
 
 type StationsProviderProps = {
@@ -26,10 +15,8 @@ type StationsProviderProps = {
 };
 
 export const StationsProvider = ({ children }: StationsProviderProps) => {
-    // TO-DO move generic states to AppStore
     const dataService = new DataService();
     const [stations, setStations] = useState([]);
-    const [isStationModalOpen, setIsStationModalOpen] = useState(false);
 
     const fetchStationsData = async () => {
         await dataService
@@ -44,10 +31,6 @@ export const StationsProvider = ({ children }: StationsProviderProps) => {
             });
     };
 
-    const handleModal = (isStationModalOpen: boolean) => {
-        setIsStationModalOpen(isStationModalOpen);
-    };
-
     useEffect(() => {
         fetchStationsData();
     }, []);
@@ -55,17 +38,11 @@ export const StationsProvider = ({ children }: StationsProviderProps) => {
     const value = useMemo(
         () => ({
             stations,
-            isStationModalOpen,
-            handleModal,
         }),
-        [stations, isStationModalOpen]
+        [stations]
     );
 
-    return (
-        <StationsContext.Provider value={value}>
-            {children}
-        </StationsContext.Provider>
-    );
+    return <StationsContext.Provider value={value}>{children}</StationsContext.Provider>;
 };
 
 export const useStationsProvider = () => {

--- a/src/utils/weatherDataFormatUtils.ts
+++ b/src/utils/weatherDataFormatUtils.ts
@@ -1,0 +1,78 @@
+import { WeatherData } from "@/types";
+
+type literalOptions = {
+    [key: string]: string;
+};
+
+/**
+ * @todo Propably move these literals to some place better. Maybe i18n?
+ */
+const literals: literalOptions = {
+    cloudy: "Cloudy",
+    cold: "Cold!",
+    dreary_overcast: "Dreary overcast",
+    flurries: "Flurries",
+    fog: "Fog",
+    freezing_rain: "Freezing rain",
+    hazy_sunshine: "Hazy sunshine",
+    hot: "Hot!",
+    ice: "Icy conditions",
+    intermittent_clouds: "Intermittent clouds",
+    light_rain: "Light rain",
+    mostly_cloudy_w_flurries: "Mostly cloudy with flurries",
+    mostly_cloudy_w_showers: "Mostly cloudy with showers",
+    mostly_cloudy_w_snow: "Mostly cloudy with snow",
+    "mostly_cloudy_w_t-storms": "Mostly cloudy with thunderstorms",
+    mostly_cloudy: "Mostly cloudy",
+    mostly_sunny: "Mostly sunny",
+    partly_cloudy_w_flurries: "Partly loudy with flurries",
+    partly_cloudy_w_showers: "Partly loudy with showers",
+    "partly_cloudy_w_t-storms": "Partly loudy with thunderstorms",
+    partly_sunny: "Partly sunny",
+    rain_and_snow: "Rain & snow",
+    rain: "Rain",
+    showers: "Showers",
+    sleet: "Sleet",
+    snow: "Snow",
+    "t-storms": "Thunderstorms",
+    thunderstorm: "Thunderstorm",
+    windy: "Windy",
+    clear: "Clear night",
+    sunny: "Sunny",
+    mostly_clear: "Mostly clear",
+    hazy_moonlight: "Hazy moonlight",
+};
+
+export const weatherConditionsText = (text: string): string => {
+    return literals[text];
+};
+
+export const formatDate = (inputDate: Date): string => {
+    const options: Intl.DateTimeFormatOptions = {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        hour12: false,
+    };
+    const date: Date = new Date(inputDate);
+    const formattedDate: string = date.toLocaleDateString("en-US", options);
+    return formattedDate;
+};
+
+export const buildExportedWeatherDataObject = (elem: WeatherData) => {
+    return {
+        date_created: elem.date_created,
+        temperature: elem.temperature,
+        humidity: elem.humidity,
+        barometer: elem.barometer,
+        percipitation: elem.percipitation,
+        rainrate: elem.rainrate,
+        windspd: elem.windspd,
+        winddir: elem.winddir,
+        station: elem.weather_station_id,
+        weatherDescription: elem.weather_condition,
+        assetId: elem.weather_condition_icon,
+    };
+};


### PR DESCRIPTION
- Use zustand to manage the state across the application
- Split the StationsProvider logic, keep the Provider only for fetching the stations and move any extra logic to the AppStore 
- Create `weatherDataFormatUtils` and move util methods outside the StationModalContent to keep the component lighter during the rendering. I've split the component into 2 smaller ones just for readability but happy to revert the change if we don't like it.