### PR TITLE
task(stationModal): Removed the literals for old weather description. Openweather API provides better literals. FWM-48

### DIFF
--- a/src/components/Home/StationWeatherSummary.tsx
+++ b/src/components/Home/StationWeatherSummary.tsx
@@ -1,7 +1,7 @@
 import { ExportedWeatherData } from "@/types";
 import { LinkIcon } from "@heroicons/react/24/solid";
 import BaseWeatherIcon from "../BaseComponents/BaseWeatherIcon";
-import { formatDate, weatherConditionsText } from "@/utils/weatherDataFormatUtils";
+import { formatDate } from "@/utils/weatherDataFormatUtils";
 
 export function StationWeatherSummary(elem: Readonly<ExportedWeatherData>) {
     return (
@@ -29,8 +29,8 @@ export function StationWeatherSummary(elem: Readonly<ExportedWeatherData>) {
                 <h3 className="text-5xl font-bold mx-auto">
                     {elem.temperature}
                     <sup className="font-normal text-lg ml-1">°C</sup>
-                    <small className="block text-base font-normal">
-                        {weatherConditionsText(elem.weatherDescription)}
+                    <small className="block text-base font-normal capitalize">
+                        {elem.weatherDescription}
                     </small>
                 </h3>
             </div>

--- a/src/utils/weatherDataFormatUtils.ts
+++ b/src/utils/weatherDataFormatUtils.ts
@@ -1,52 +1,5 @@
 import { WeatherData } from "@/types";
 
-type literalOptions = {
-    [key: string]: string;
-};
-
-/**
- * @todo Propably move these literals to some place better. Maybe i18n?
- */
-const literals: literalOptions = {
-    cloudy: "Cloudy",
-    cold: "Cold!",
-    dreary_overcast: "Dreary overcast",
-    flurries: "Flurries",
-    fog: "Fog",
-    freezing_rain: "Freezing rain",
-    hazy_sunshine: "Hazy sunshine",
-    hot: "Hot!",
-    ice: "Icy conditions",
-    intermittent_clouds: "Intermittent clouds",
-    light_rain: "Light rain",
-    mostly_cloudy_w_flurries: "Mostly cloudy with flurries",
-    mostly_cloudy_w_showers: "Mostly cloudy with showers",
-    mostly_cloudy_w_snow: "Mostly cloudy with snow",
-    "mostly_cloudy_w_t-storms": "Mostly cloudy with thunderstorms",
-    mostly_cloudy: "Mostly cloudy",
-    mostly_sunny: "Mostly sunny",
-    partly_cloudy_w_flurries: "Partly loudy with flurries",
-    partly_cloudy_w_showers: "Partly loudy with showers",
-    "partly_cloudy_w_t-storms": "Partly loudy with thunderstorms",
-    partly_sunny: "Partly sunny",
-    rain_and_snow: "Rain & snow",
-    rain: "Rain",
-    showers: "Showers",
-    sleet: "Sleet",
-    snow: "Snow",
-    "t-storms": "Thunderstorms",
-    thunderstorm: "Thunderstorm",
-    windy: "Windy",
-    clear: "Clear night",
-    sunny: "Sunny",
-    mostly_clear: "Mostly clear",
-    hazy_moonlight: "Hazy moonlight",
-};
-
-export const weatherConditionsText = (text: string): string => {
-    return literals[text];
-};
-
 export const formatDate = (inputDate: Date): string => {
     const options: Intl.DateTimeFormatOptions = {
         weekday: "short",


### PR DESCRIPTION
Small change regarding the way the weather description text shows inside the modal.
Old Accuweather had complicated weather description so we had to manipulate the text a bit. 
Openweather provides more clear text, so it can be used as is.
Without the BE changes, in the app you will just see the description as it comes from the endpoint.
![Screenshot 2024-03-24 at 9 24 32 AM](https://github.com/Weath-r/fwm-app/assets/18416386/62b55250-251d-48d6-87d1-438fa86e5706)
![Screenshot 2024-03-24 at 9 25 29 AM](https://github.com/Weath-r/fwm-app/assets/18416386/fc682bb4-33b9-4415-93a6-17ca3d4f4c1c)

