### PR TITLE
fix(search-form): Clear search form when closing station modal #80

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,7 +44,7 @@ export default function Home() {
                 </aside>
                 <div className="absolute left-2 top-2 z-[2] h-[40px] w-[240px]">
                     <MapSearchForm 
-                        handleSearchResult={handleModal}
+                        showStationModal={handleModal}
                     ></MapSearchForm>
                 </div>
                 <HomepageMap></HomepageMap>

--- a/src/components/Home/ForecastLayer.tsx
+++ b/src/components/Home/ForecastLayer.tsx
@@ -118,7 +118,6 @@ export default function ForecastLayer() {
     const createGradient = () => {
         const colors: string[] = [];
         TemperatureColorList.forEach(color => colors.push(hexToRgba(color, .6)));
-        console.log(`linear-gradient(to right, ${colors.join(", ")})`);
         return `linear-gradient(to right, ${colors.join(", ")})`;
     };
 

--- a/src/components/Home/SearchForm/MapSearchForm.tsx
+++ b/src/components/Home/SearchForm/MapSearchForm.tsx
@@ -1,37 +1,27 @@
-import Select from "react-dropdown-select";
+import { useAppStore } from "@/hooks/useAppStore";
 import { useStationsProvider } from "@/providers/StationsProvider";
-import { useState, useEffect } from "react";
-import CommonButton from "@/components/Common/CommonButton";
-import { XCircleIcon } from "@heroicons/react/24/solid";
 import { Station } from "@/types";
+import Select from "react-dropdown-select";
 
-type SearchValue = {
-    name: string;
-    id: number;
-};
 type SearchFormProps = {
-    handleSearchResult: (val: number) => void;
+    showStationModal: (val: number) => void;
 };
 
-export default function MapSearchForm(props: SearchFormProps) {
+export default function MapSearchForm(props: Readonly<SearchFormProps>) {
+    const { activeStation } = useAppStore();
     const { stations } = useStationsProvider();
-    const [selectedValue, setSelectedValue] = useState<SearchValue[]>([]);
-    const [sortedStations, setSortedStations] = useState<Station[]>([]);
+
+    const sortedStations = stations.toSorted((a, b) => a.name.localeCompare(b.name));
     
-    const handleOnChange = (value: SearchValue[]) => {
-        return setSelectedValue(value);
-    };
+    const getStationById = (id: number) => {
+        return stations.filter( station =>  station.id == id)[0];
+    }
 
-    useEffect(() => {
-        if (selectedValue.length > 0) {
-            props.handleSearchResult(selectedValue[0].id);
+    const handleOnChange = (selectedStations: Station[]) => {
+        if (selectedStations.length > 0) {
+            props.showStationModal(selectedStations[0].id);
         }
-    }, [selectedValue]);
-
-    useEffect(() => {
-        const getSortedStations = stations.toSorted((a, b) => a.name.localeCompare(b.name));
-        setSortedStations(getSortedStations);
-    }, [stations]);
+    };
 
     return (
         <Select
@@ -44,29 +34,11 @@ export default function MapSearchForm(props: SearchFormProps) {
             placeholder="Search station"
             closeOnSelect={true}
             className="h-[40px] !rounded-lg !border-0 !bg-white/90 !p-2.5 !font-normal text-primary !shadow-sm focus:outline-none"
-            itemRenderer={({ item, methods }) => {
-                return (
-                    <div 
-                        className="m-2 pl-2 text-primary"
-                        onClick={() => methods.addItem(item)}
-                    >
-                        {item.name}
-                    </div>
-                );
-            }}
-            clearRenderer={
-                ({ state, methods }) => {
-                    return state.values.length > 0 ? (
-                        <CommonButton color="secondary" handleClick={methods.clearAll}>
-                            <XCircleIcon className="size-7 p-1"></XCircleIcon>
-                        </CommonButton>
-                    ) : (<span></span>);
-                }
-            }
+            clearRenderer={() => <></>}
             dropdownGap={0}
             options={sortedStations}
-            values={selectedValue}
-            onChange={handleOnChange}
+            values={activeStation != 0 ? [getStationById(activeStation)] : []}
+            onChange={(values) => handleOnChange(values)}
         />
     );
 }


### PR DESCRIPTION
Refactor the MapSearchForm component as follows:
1. clear automatically the search form after closing the station modal popup
2. rely on the activeStation to remove the need of using multiple states. The activeStation from the store is all we need to show/hide the popup
3. removed the state for `sortedStations` - it relies on the stations which comes from the provider, so every time there is a change there, it will cause a re-render, and thus there is no need to keep another state
4. updated `clearRenderer` to always return an empty fragment as we don't need the closing button anymore
5. removed `itemRenderer` as the default behaviour seems to be sufficient to show the station name in the form
6. few renamings that helped me when going through the code

Feedback always welcome! 🙏 