### PR TITLE
feat(favouriteStations): Enable users select their favourite stations and filter them

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
         "zustand": "4.5.0"
     },
     "devDependencies": {
-        "@types/leaflet": "1.9.4",
         "@types/d3": "7.4.3",
+        "@types/leaflet": "1.9.4",
         "@types/leaflet.markercluster": "1.5.4",
         "@types/node": "20.6.2",
         "@types/react": "18.2.21",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,37 +1,41 @@
 "use client";
-import "leaflet/dist/leaflet.css";
-import { StationsProvider } from "@/providers/StationsProvider";
-import { useMarkerStationsClick } from "@/hooks/useMarkerStations";
-import dynamic from "next/dynamic";
-
-const HomepageMap = dynamic(
-    () => import("@/components/Home/HomepageMap"),
-    {
-        ssr: false,
-    }
-);
-const WarningsPanel = dynamic(
-    () => import("@/components/Warnings/WarningsPanel"),
-    {
-        ssr: false,
-    }
-);
-const MobileWarnings = dynamic(
-    () => import("@/components/Warnings/MobileWarnings"),
-    {
-        ssr: false,
-    }
-);
-const MapSearchForm = dynamic(
-    () => import("@/components/Home/SearchForm/MapSearchForm"),
-    {
-        ssr: false,
-    }
-);
+import CommonButton from "@/components/Common/CommonButton";
 import ForecastLayer from "@/components/Home/ForecastLayer";
+import { useAppStore } from "@/hooks/useAppStore";
+import { useMarkerStationsClick } from "@/hooks/useMarkerStations";
+import { StationsProvider } from "@/providers/StationsProvider";
+import { HeartIcon as HeartIconOutline } from "@heroicons/react/24/outline";
+import { HeartIcon } from "@heroicons/react/24/solid";
+import "leaflet/dist/leaflet.css";
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
+
+const HomepageMap = dynamic(() => import("@/components/Home/HomepageMap"), {
+    ssr: false,
+});
+const WarningsPanel = dynamic(() => import("@/components/Warnings/WarningsPanel"), {
+    ssr: false,
+});
+const MobileWarnings = dynamic(() => import("@/components/Warnings/MobileWarnings"), {
+    ssr: false,
+});
+const MapSearchForm = dynamic(() => import("@/components/Home/SearchForm/MapSearchForm"), {
+    ssr: false,
+});
 
 export default function Home() {
     const { handleModal } = useMarkerStationsClick();
+    const { setShowFavouriteStations, showFavouriteStations, favouriteStations } = useAppStore();
+
+    const [isMounted, setIsMounted] = useState(false);
+
+    useEffect(() => {
+        setIsMounted(true);
+    }, []);
+
+    if (!isMounted) {
+        return null; // Ensure consistent server-client output
+    }
 
     return (
         <StationsProvider>
@@ -42,10 +46,20 @@ export default function Home() {
                 <aside className="absolute right-0 top-1 z-[2] w-full lg:hidden">
                     <MobileWarnings></MobileWarnings>
                 </aside>
-                <div className="absolute left-2 top-2 z-[2] h-[40px] w-[240px]">
-                    <MapSearchForm 
-                        showStationModal={handleModal}
-                    ></MapSearchForm>
+                <div className="absolute left-2 top-2 z-[2] flex h-[40px] w-[240px] items-center gap-2">
+                    <MapSearchForm showStationModal={handleModal}></MapSearchForm>
+                    {favouriteStations.length > 0 && (
+                        <CommonButton
+                            handleClick={() => setShowFavouriteStations(!showFavouriteStations)}
+                            color="danger"
+                        >
+                            {typeof window !== "undefined" && showFavouriteStations ? (
+                                <HeartIcon className="size-8 p-1" />
+                            ) : (
+                                <HeartIconOutline className="size-8 p-1" />
+                            )}
+                        </CommonButton>
+                    )}
                 </div>
                 <HomepageMap></HomepageMap>
                 <section className="fixed bottom-0 z-[2] w-full lg:bottom-0">

--- a/src/components/BaseComponents/BaseModal.tsx
+++ b/src/components/BaseComponents/BaseModal.tsx
@@ -1,22 +1,26 @@
 "use client";
-import { Dialog, Transition } from "@headlessui/react";
-import { Fragment, ReactNode } from "react";
 import CommonButton from "@/components/Common/CommonButton";
-import { XCircleIcon } from "@heroicons/react/24/solid";
+import { useAppStore } from "@/hooks/useAppStore";
+import { Dialog, Transition } from "@headlessui/react";
+import { HeartIcon, XCircleIcon } from "@heroicons/react/24/solid";
+import { Fragment, ReactNode } from "react";
 
 type BaseModalProps = {
     children: ReactNode;
     handleCloseModal: () => void;
+    handleFavouriteButton: (stationId: number) => void;
     isModalOpen: boolean;
     dialogClass?: string;
 };
 
-export default function BaseModal({ 
+export default function BaseModal({
     children,
     handleCloseModal,
+    handleFavouriteButton,
     isModalOpen,
     dialogClass,
 }: Readonly<BaseModalProps>) {
+    const { activeStation, isStationFavourite } = useAppStore();
     return (
         <Transition appear show={isModalOpen} as={Fragment}>
             <Dialog
@@ -37,12 +41,24 @@ export default function BaseModal({
                             leaveFrom="opacity-100 scale-100"
                             leaveTo="opacity-0 scale-95"
                         >
-                            <Dialog.Panel className={`min-h-[430px] w-full overflow-hidden rounded-2xl bg-white p-2 text-left shadow-xl transition-all ${dialogClass}`}>
+                            <Dialog.Panel
+                                className={`min-h-[430px] w-full overflow-hidden rounded-2xl bg-white p-2 text-left shadow-xl transition-all ${dialogClass}`}
+                            >
                                 <Dialog.Description as="section">
                                     {children}
-                                    <div className="absolute right-3 top-3">
+                                    <div className="absolute right-3 top-3 flex gap-2 items-center">
+                                        <CommonButton
+                                            handleClick={() => handleFavouriteButton(activeStation)}
+                                            color={
+                                                isStationFavourite(activeStation)
+                                                    ? "primary"
+                                                    : "secondary"
+                                            }
+                                        >
+                                            <HeartIcon className="size-8 p-1" />
+                                        </CommonButton>
                                         <CommonButton handleClick={handleCloseModal} color="danger">
-                                            <XCircleIcon className="size-8 p-1"></XCircleIcon>
+                                            <XCircleIcon className="size-8 p-1" />
                                         </CommonButton>
                                     </div>
                                 </Dialog.Description>

--- a/src/components/Common/CommonButton.tsx
+++ b/src/components/Common/CommonButton.tsx
@@ -18,6 +18,8 @@ export default function CommonButton(props: Readonly<CommonButtonProps>) {
         textColor = "text-primary";
     } else if (props.color === "danger") {
         textColor = "text-danger";
+    } else if (props.color === "secondary") {
+        textColor = "text-secondary";
     }
     return (
         <button

--- a/src/components/Header/HeaderMenu.tsx
+++ b/src/components/Header/HeaderMenu.tsx
@@ -1,21 +1,24 @@
+import { useConfigurationStore } from "@/stores/configurationStore";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useConfigurationStore } from "@/stores/configurationStore";
 
 export default function HeaderMenu() {
     const pathname = usePathname();
     const { menu } = useConfigurationStore();
-    
-    return (<section>
-        {menu.map(element => 
-            <Link
-                className={`px-2 text-lg text-primary ${pathname === element.pathName ? "font-bold text-success" : ""}`}
-                href={element.pathName}
-                key={element.text}
-            >
-                {element.text}
-            </Link>
-        )}
-    </section>
+
+    return (
+        <section>
+            {menu.map((element) => (
+                <Link
+                    className={`px-2 text-lg text-primary ${
+                        pathname === element.pathName ? "font-bold text-success" : ""
+                    }`}
+                    href={element.pathName}
+                    key={element.text}
+                >
+                    {element.text}
+                </Link>
+            ))}
+        </section>
     );
 }

--- a/src/components/Header/MobileHeaderMenu.tsx
+++ b/src/components/Header/MobileHeaderMenu.tsx
@@ -1,7 +1,7 @@
+import { useConfigurationStore } from "@/stores/configurationStore";
 import { Menu } from "@headlessui/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useConfigurationStore } from "@/stores/configurationStore";
 import SvgInline from "../Common/SvgInline";
 
 export default function MobileHeaderMenu() {
@@ -10,26 +10,25 @@ export default function MobileHeaderMenu() {
 
     return (
         <Menu>
-            <Menu.Button className="font-bold text-primary"> 
-                <SvgInline 
-                    path="/icons/menu.svg"
-                    className="w-6 fill-primary"
-                ></SvgInline>
+            <Menu.Button className="font-bold text-primary">
+                <SvgInline path="/icons/menu.svg" className="w-6 fill-primary"></SvgInline>
             </Menu.Button>
             <Menu.Items className="mr-4 mt-6 flex w-full flex-col gap-1 rounded-b border-t-2 border-solid border-accent bg-white px-4 pb-2 shadow-lg">
                 <Menu.Item>
                     <h3 className="my-2 text-sm uppercase text-primary opacity-50">Menu</h3>
                 </Menu.Item>
-                {menu.map(elem =>
+                {menu.map((elem) => (
                     <Menu.Item key={elem.text}>
                         <Link
-                            className={`text-md p-1 pl-0 text-primary ${pathname === elem.pathName ? "font-bold text-success" : ""}`}
+                            className={`text-md p-1 pl-0 text-primary ${
+                                pathname === elem.pathName ? "font-bold text-success" : ""
+                            }`}
                             href={elem.pathName}
                         >
                             {elem.text}
                         </Link>
                     </Menu.Item>
-                )}
+                ))}
             </Menu.Items>
         </Menu>
     );

--- a/src/components/Home/SearchForm/MapSearchForm.tsx
+++ b/src/components/Home/SearchForm/MapSearchForm.tsx
@@ -12,10 +12,10 @@ export default function MapSearchForm(props: Readonly<SearchFormProps>) {
     const { stations } = useStationsProvider();
 
     const sortedStations = stations.toSorted((a, b) => a.name.localeCompare(b.name));
-    
+
     const getStationById = (id: number) => {
-        return stations.filter( station =>  station.id == id)[0];
-    }
+        return stations.filter((station) => station.id == id)[0];
+    };
 
     const handleOnChange = (selectedStations: Station[]) => {
         if (selectedStations.length > 0) {

--- a/src/components/Home/WeatherModal/StationWeatherForecastDetails.tsx
+++ b/src/components/Home/WeatherModal/StationWeatherForecastDetails.tsx
@@ -102,7 +102,7 @@ export function StationWeatherForecastDetails(elem: WeatherData) {
                 })}
             </div>
             <div className="mt-2 max-h-[280px] overflow-y-auto">
-                {structuredForecast[forecastDate].map((forecast,index, forecastArray) => {
+                {structuredForecast[forecastDate] && structuredForecast[forecastDate].map((forecast,index, forecastArray) => {
                     const forecastTime = new Date(forecast.time);
                     const shouldRenderForecast = index === forecastArray.length - 1 
                         ? true 

--- a/src/components/Stations/StationsPage.tsx
+++ b/src/components/Stations/StationsPage.tsx
@@ -1,16 +1,48 @@
-import { useState, useEffect } from "react";
+import { useAppStore } from "@/hooks/useAppStore";
 import { DataService } from "@/services/DataService";
 import { WeatherDataResponse } from "@/types";
+import { AccessorFnColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
 import StationsTableData from "./components/StationsTableData";
+import { getColumns } from "./components/StationTableColumns";
+
+const getStationsTable = (
+    title: string,
+    weatherTableData: WeatherDataResponse[],
+    columns: (
+        | AccessorFnColumnDef<WeatherDataResponse, string>
+        | AccessorFnColumnDef<WeatherDataResponse, number>
+    )[]
+) => {
+    return (
+        <div className="mx-4 mt-4 md:container md:mx-auto">
+            <h2 className="mb-4 text-2xl text-primary">
+                {title}
+                <small className="block text-sm text-primary opacity-60">
+                    {weatherTableData.length} active
+                </small>
+            </h2>
+            <div className="my-4 w-full overflow-x-scroll rounded-xl bg-white p-4 drop-shadow-md md:overflow-x-auto">
+                <StationsTableData
+                    title={title}
+                    data={weatherTableData}
+                    columns={columns}
+                ></StationsTableData>
+            </div>
+        </div>
+    );
+};
 
 export default function StationsPage() {
     const dataService = new DataService();
     const [weatherTableData, setWeatherTableData] = useState<WeatherDataResponse[]>([]);
+    const { favouriteStations, isStationFavourite, handleFavouriteStationButton } = useAppStore();
+
     const getWeatherData = async () => {
         await dataService
             .fetchWeatherStationsWithData()
             .then((response) => {
-                return setWeatherTableData(response);
+                setWeatherTableData(response);
             })
             .catch((error) => {
                 // TO-DO handle error properly
@@ -19,21 +51,36 @@ export default function StationsPage() {
             });
     };
 
-    useEffect(() => {
+    useMemo(() => {
         getWeatherData();
     }, []);
-   
+
+    const favSet = new Set(favouriteStations);
+    const favStations: WeatherDataResponse[] = [];
+    const remainingStations: WeatherDataResponse[] = [];
+
+    weatherTableData.forEach((station) => {
+        if (favSet.has(station.weather_station_id.id)) {
+            console.log(station.weather_station_id.id);
+            favStations.push(station);
+        } else {
+            remainingStations.push(station);
+        }
+    });
+
+    const columns = useMemo(
+        () => getColumns("Stations list", handleFavouriteStationButton, isStationFavourite),
+        []
+    );
+    const favColumns = useMemo(
+        () => getColumns("My Favourite list", handleFavouriteStationButton, isStationFavourite),
+        []
+    );
     return (
-        <div className="mx-4 mt-4 md:container md:mx-auto">
-            <h2 className="mb-4 text-2xl text-primary">
-                Stations list
-                <small className="block text-sm text-primary opacity-60">
-                    {weatherTableData.length} active
-                </small>
-            </h2>
-            <div className="my-4 w-full overflow-x-scroll rounded-xl bg-white p-4 drop-shadow-md md:overflow-x-auto">
-                <StationsTableData data={weatherTableData}></StationsTableData>
-            </div>
-        </div>
+        <>
+            {favouriteStations.length > 0 &&
+                getStationsTable("My Favourite Stations", favStations, favColumns)}
+            {getStationsTable("Stations list", remainingStations, columns)}
+        </>
     );
 }

--- a/src/components/Stations/components/StationTableColumns.tsx
+++ b/src/components/Stations/components/StationTableColumns.tsx
@@ -1,0 +1,165 @@
+import BaseWeatherIcon from "@/components/BaseComponents/BaseWeatherIcon";
+import CommonButton from "@/components/Common/CommonButton";
+import SvgInline from "@/components/Common/SvgInline";
+import { Measurements, WeatherConditions, WeatherDataResponse } from "@/types";
+import { HeartIcon } from "@heroicons/react/24/solid";
+import { createColumnHelper, SortingFn } from "@tanstack/react-table";
+import { fullDateWithTime } from "../../../utils/dateTimeUtils";
+
+// Sorting Fns
+const sortStatusFn: SortingFn<WeatherDataResponse> = (rowA, rowB) => {
+    return rowA.original.weather_station_id.name.localeCompare(
+        rowB.original.weather_station_id.name
+    );
+};
+const sortTemperatureFn: SortingFn<WeatherDataResponse> = (rowA, rowB) => {
+    return rowA.original.temperature - rowB.original.temperature;
+};
+
+// Columns initialisation
+const columnHelper = createColumnHelper<WeatherDataResponse>();
+export const getColumns = (
+    title: string,
+    handleFavouriteButton: (stationId: number) => void,
+    isStationFavourite: (stationId: number) => boolean
+) => {
+    return [
+        columnHelper.accessor(
+            (row) =>
+                `${row.weather_station_id.name}--${row.weather_station_id.prefecture_id.label}`,
+            {
+                id: "stationName",
+                cell: (info) => {
+                    const label = info.getValue().split("--");
+                    return (
+                        <p className="whitespace-nowrap pr-6 font-bold text-primary">
+                            {label[0]}{" "}
+                            <span className="block font-normal text-primary opacity-30">
+                                {label[1]}
+                            </span>
+                        </p>
+                    );
+                },
+                header: () => <span>Station name</span>,
+                sortingFn: sortStatusFn,
+            }
+        ),
+        columnHelper.accessor((row) => row.weather_condition_icon, {
+            id: "stationWeatherIcon",
+            cell: (info) => {
+                return (
+                    <div className="w-10">
+                        <BaseWeatherIcon
+                            assetId={info.getValue()}
+                            weatherDescriptionText="icon"
+                        ></BaseWeatherIcon>
+                    </div>
+                );
+            },
+            header: () => <span>Current conditions</span>,
+        }),
+        columnHelper.accessor((row) => `${row.temperature}--${row.temp_difference}`, {
+            id: "stationTemp",
+            cell: (info) => {
+                const tempLabel = info.getValue().split("--");
+                const trendArrowStyle = +tempLabel[1] > 0 ? "fill-success" : "fill-danger";
+                const trendArrowIcon =
+                    +tempLabel[1] > 0 ? "icons/arrow-up.svg" : "icons/arrow-down.svg";
+                const trendArrow = +tempLabel[1] !== 0 && (
+                    <SvgInline
+                        path={trendArrowIcon}
+                        title={`${tempLabel[1]}${Measurements.CELCIUS} in last 30 mins`}
+                        className={`w-2 ${trendArrowStyle}`}
+                    ></SvgInline>
+                );
+                return (
+                    <p className="flex items-center gap-1">
+                        {tempLabel[0]}
+                        {trendArrow}
+                    </p>
+                );
+            },
+            header: () => (
+                <p>
+                    {WeatherConditions.TEMP}
+                    <span className="ml-1 text-xs">({Measurements.CELCIUS})</span>
+                </p>
+            ),
+            sortingFn: sortTemperatureFn,
+        }),
+        columnHelper.accessor((row) => row.humidity, {
+            id: "stationHum",
+            cell: (info) => <span>{info.getValue()}</span>,
+            header: () => (
+                <p>
+                    {WeatherConditions.HUMIDITY}
+                    <span className="ml-1 text-xs">({Measurements.PERCENTAGE})</span>
+                </p>
+            ),
+        }),
+        columnHelper.accessor((row) => row.percipitation, {
+            id: "stationPerc",
+            cell: (info) => <span>{info.getValue()}</span>,
+            header: () => (
+                <p>
+                    {WeatherConditions.RAIN}
+                    <span className="ml-1 text-xs">({Measurements.MILLIMETER})</span>
+                </p>
+            ),
+        }),
+        columnHelper.accessor((row) => row.windspd, {
+            id: "stationWindSpd",
+            cell: (info) => <span>{info.getValue()}</span>,
+            header: () => (
+                <p>
+                    {WeatherConditions.WIND}
+                    <span className="ml-1 text-xs">({Measurements.SPEED})</span>
+                </p>
+            ),
+        }),
+        columnHelper.accessor((row) => row.winddir, {
+            id: "stationWindDir",
+            cell: (info) => {
+                const windspd = info.getValue();
+                return (
+                    <div className="h-4 w-6">
+                        <SvgInline
+                            path="weather_icons/wind.svg"
+                            title="Wind icon"
+                            className="fill-primary"
+                            style={{
+                                transform: `rotate(${windspd}deg)`,
+                            }}
+                        />
+                    </div>
+                );
+            },
+            header: () => <p>{WeatherConditions.WINDDIR}</p>,
+        }),
+        columnHelper.accessor((row) => row.date_created, {
+            id: "stationUpdate",
+            cell: (info) => {
+                return <span>{fullDateWithTime(info.getValue())}</span>;
+            },
+            header: () => <p>Last update</p>,
+            enableSorting: false,
+        }),
+        columnHelper.accessor((row) => row.weather_station_id.id, {
+            id: "stationFavourite",
+            cell: (info) => {
+                return (
+                    <div>
+                        <CommonButton
+                            handleClick={() => handleFavouriteButton(info.getValue())}
+                            color={isStationFavourite(info.getValue()) ? "primary" : "secondary"}
+                        >
+                            <HeartIcon className="size-8 p-1" />
+                        </CommonButton>
+                    </div>
+                );
+            },
+            header: () => <span>Favourite</span>,
+            enableSorting: false,
+        })
+    ];
+};

--- a/src/components/Stations/components/StationsTableData.tsx
+++ b/src/components/Stations/components/StationsTableData.tsx
@@ -1,123 +1,27 @@
+import SvgInline from "@/components/Common/SvgInline";
+import { WeatherDataResponse } from "@/types";
 import {
-    createColumnHelper,
+    AccessorFnColumnDef,
     flexRender,
     getCoreRowModel,
     getSortedRowModel,
+    SortingState,
     useReactTable,
-    SortingFn,
-    SortingState
 } from "@tanstack/react-table";
-import { WeatherDataResponse, Measurements, WeatherConditions } from "@/types";
-import BaseWeatherIcon from "@/components/BaseComponents/BaseWeatherIcon";
-import SvgInline from "@/components/Common/SvgInline";
 
 import { useState } from "react";
-import { fullDateWithTime } from "@/utils/dateTimeUtils";
 
 type TableDataProps = {
-    data: WeatherDataResponse[]
+    title: string;
+    data: WeatherDataResponse[];
+    columns: (
+        | AccessorFnColumnDef<WeatherDataResponse, string>
+        | AccessorFnColumnDef<WeatherDataResponse, number>
+    )[];
 };
 
-// Sorting Fns
-const sortStatusFn: SortingFn<WeatherDataResponse> = (rowA, rowB) => {
-    return rowA.original.weather_station_id.name.localeCompare(rowB.original.weather_station_id.name);
-};
-const sortTemperatureFn: SortingFn<WeatherDataResponse> = (rowA, rowB) => {
-    return rowA.original.temperature - rowB.original.temperature; 
-};
-
-// Columns initialisation
-const columnHelper = createColumnHelper<WeatherDataResponse>();
-const columns = [
-    columnHelper.accessor(row => `${row.weather_station_id.name}--${row.weather_station_id.prefecture_id.label}`, {
-        id: "stationName",
-        cell: info => {
-            const label = info.getValue().split("--");
-            return (
-                <p className="whitespace-nowrap pr-6 font-bold text-primary">{label[0]} <span className="block font-normal text-primary opacity-30">{label[1]}</span></p>
-            );
-        },
-        header: () => <span>Station name</span>,
-        sortingFn: sortStatusFn,
-    }),
-    columnHelper.accessor(row => row.weather_condition_icon, {
-        id: "stationWeatherIcon",
-        cell: info => {
-            return (
-                <div className="w-10">
-                    <BaseWeatherIcon assetId={info.getValue()} weatherDescriptionText="icon" ></BaseWeatherIcon>
-                </div>
-            );
-        },
-        header: () => <span>Current conditions</span>,
-    }),
-    columnHelper.accessor(row => `${row.temperature}--${row.temp_difference}`, {
-        id: "stationTemp",
-        cell: info => {
-            const tempLabel = info.getValue().split("--");
-            const trendArrowStyle = +tempLabel[1] > 0 ? "fill-success" : "fill-danger";
-            const trendArrowIcon = +tempLabel[1] > 0 ? "icons/arrow-up.svg" : "icons/arrow-down.svg";
-            const trendArrow = +tempLabel[1] !== 0 && <SvgInline 
-                path={trendArrowIcon}
-                title={`${tempLabel[1]}${Measurements.CELCIUS} in last 30 mins`}
-                className={`w-2 ${trendArrowStyle}`}
-            ></SvgInline>;
-            return (
-                <p className="flex items-center gap-1">
-                    {tempLabel[0]}
-                    {trendArrow}
-                </p>
-            );
-        },
-        header: () => <p>{WeatherConditions.TEMP}<span className="ml-1 text-xs">({Measurements.CELCIUS})</span></p>,
-        sortingFn: sortTemperatureFn,
-    }),
-    columnHelper.accessor(row => row.humidity, {
-        id: "stationHum",
-        cell: info => <span>{info.getValue()}</span>,
-        header: () => <p>{WeatherConditions.HUMIDITY}<span className="ml-1 text-xs">({Measurements.PERCENTAGE})</span></p>,
-    }),
-    columnHelper.accessor(row => row.percipitation, {
-        id: "stationPerc",
-        cell: info => <span>{info.getValue()}</span>,
-        header: () => <p>{WeatherConditions.RAIN}<span className="ml-1 text-xs">({Measurements.MILLIMETER})</span></p>,
-    }),
-    columnHelper.accessor(row => row.windspd, {
-        id: "stationWindSpd",
-        cell: info => <span>{info.getValue()}</span>,
-        header: () => <p>{WeatherConditions.WIND}<span className="ml-1 text-xs">({Measurements.SPEED})</span></p>,
-    }),
-    columnHelper.accessor(row => row.winddir, {
-        id: "stationWindDir",
-        cell: info => {
-            const windspd = info.getValue();
-            return (
-                <div className="h-4 w-6">
-                    <SvgInline
-                        path="weather_icons/wind.svg"
-                        title="Wind icon"
-                        className="fill-primary"
-                        style={{
-                            transform: `rotate(${windspd}deg)`,
-                        }}
-                    />
-                </div>
-            );
-        },
-        header: () => <p>{WeatherConditions.WINDDIR}</p>,
-    }),
-    columnHelper.accessor(row => row.date_created, {
-        id: "stationUpdate",
-        cell: info => {
-            return <span>{fullDateWithTime(info.getValue())}</span>;
-        },
-        header: () => <p>Last update</p>,
-        enableSorting: false,
-    })
-];
-  
 export default function StationsTableData(props: Readonly<TableDataProps>) {
-    const { data } = props;
+    const { data, columns } = props;
     const [sorting, setSorting] = useState<SortingState>([]);
 
     const table = useReactTable({
@@ -133,57 +37,64 @@ export default function StationsTableData(props: Readonly<TableDataProps>) {
     return (
         <table className="w-full text-left text-sm text-primary">
             <thead className="text-xs uppercase text-primary">
-                {table.getHeaderGroups().map(headerGroup => (
+                {table.getHeaderGroups().map((headerGroup) => (
                     <tr key={headerGroup.id}>
-                        {headerGroup.headers.map(header => (
-                            <th key={header.id} scope="col" className="px-6 py-3" colSpan={header.colSpan}>
-                                {header.isPlaceholder
-                                    ? null
-                                    : (
-                                        <div
-                                            className={
-                                                header.column.getCanSort()
-                                                    ? "flex cursor-pointer select-none items-center gap-1"
-                                                    : ""
-                                            }
-                                            onClick={header.column.getToggleSortingHandler()}
-                                            title={
-                                                header.column.getCanSort()
-                                                    ? header.column.getNextSortingOrder() === "asc"
-                                                        ? "Sort ascending"
-                                                        : header.column.getNextSortingOrder() === "desc"
-                                                            ? "Sort descending"
-                                                            : "Clear sort"
-                                                    : undefined
-                                            }
-                                        >
-                                            {flexRender(
-                                                header.column.columnDef.header,
-                                                header.getContext()
-                                            )}
-                                            {{
-                                                asc: <SvgInline
+                        {headerGroup.headers.map((header) => (
+                            <th
+                                key={header.id}
+                                scope="col"
+                                className="px-6 py-3"
+                                colSpan={header.colSpan}
+                            >
+                                {header.isPlaceholder ? null : (
+                                    <div
+                                        className={
+                                            header.column.getCanSort()
+                                                ? "flex cursor-pointer select-none items-center gap-1"
+                                                : ""
+                                        }
+                                        onClick={header.column.getToggleSortingHandler()}
+                                        title={
+                                            header.column.getCanSort()
+                                                ? header.column.getNextSortingOrder() === "asc"
+                                                    ? "Sort ascending"
+                                                    : header.column.getNextSortingOrder() === "desc"
+                                                    ? "Sort descending"
+                                                    : "Clear sort"
+                                                : undefined
+                                        }
+                                    >
+                                        {flexRender(
+                                            header.column.columnDef.header,
+                                            header.getContext()
+                                        )}
+                                        {{
+                                            asc: (
+                                                <SvgInline
                                                     path="icons/caret-up.svg"
                                                     title="Sort ascending"
                                                     className="w-2 fill-primary"
-                                                />,
-                                                desc: <SvgInline
+                                                />
+                                            ),
+                                            desc: (
+                                                <SvgInline
                                                     path="icons/caret-down.svg"
                                                     title="Sort descending"
                                                     className="w-2 fill-primary"
-                                                />,
-                                            }[header.column.getIsSorted() as string] ?? null}
-                                        </div>
-                                    )}
+                                                />
+                                            ),
+                                        }[header.column.getIsSorted() as string] ?? null}
+                                    </div>
+                                )}
                             </th>
                         ))}
                     </tr>
                 ))}
             </thead>
             <tbody>
-                {table.getRowModel().rows.map(row => (
+                {table.getRowModel().rows.map((row) => (
                     <tr key={row.id} className="border-b border-secondary">
-                        {row.getVisibleCells().map(cell => (
+                        {row.getVisibleCells().map((cell) => (
                             <td key={cell.id} className="px-6 py-4">
                                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
                             </td>

--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -1,3 +1,9 @@
+import {
+    getFavouritesStationList,
+    getShowFavouriteStations,
+    storeFavouriteStationsList,
+    storeShowFavouriteStations
+} from "@/utils/localStorage";
 import { create } from "zustand";
 
 type AppStore = {
@@ -5,9 +11,14 @@ type AppStore = {
     setIsStationModalOpen: (value: boolean) => void;
     activeStation: number;
     setActiveStation: (stationId: number) => void;
+    isStationFavourite: (stationId: number) => boolean;
+    favouriteStations: number[];
+    handleFavouriteStationButton: (stationId: number) => void;
+    showFavouriteStations: boolean;
+    setShowFavouriteStations: (value: boolean) => void;
 };
 
-export const useAppStore = create<AppStore>((set) => ({
+export const useAppStore = create<AppStore>((set, get) => ({
     isStationModalOpen: false,
     setIsStationModalOpen: (isStationModalOpen) => {
         set(() => ({ isStationModalOpen }));
@@ -15,5 +26,30 @@ export const useAppStore = create<AppStore>((set) => ({
     activeStation: 0,
     setActiveStation: (activeStation) => {
         set(() => ({ activeStation }));
+    },
+    favouriteStations: getFavouritesStationList(),
+    isStationFavourite: (stationId: number) => {
+        const storedFavouriteStations = getFavouritesStationList();
+        return storedFavouriteStations.includes(stationId);
+    },
+    handleFavouriteStationButton: (stationId: number) => {
+        if (getFavouritesStationList().includes(stationId)) {
+            set((state) => ({
+                favouriteStations: state.favouriteStations.filter((id) => stationId !== id),
+            }));
+        } else {
+            set((state) => ({ favouriteStations: [...state.favouriteStations, stationId] }));
+        }
+
+        if (get().favouriteStations.length === 0) {
+            set(() => ({ showFavouriteStations: false }));
+            storeShowFavouriteStations(false);
+        }
+        storeFavouriteStationsList(get().favouriteStations);
+    },
+    showFavouriteStations: getShowFavouriteStations(),
+    setShowFavouriteStations: (showFavouriteStations) => {
+        set(() => ({ showFavouriteStations }));
+        storeShowFavouriteStations(showFavouriteStations);
     },
 }));

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,0 +1,37 @@
+export const FAVOURITES_STATION_LOCAL_STORAGE_KEY = "favouriteStations";
+export const SHOW_FAVOURITES_STATION_LOCAL_STORAGE_KEY = "showFavouriteStations";
+
+export const getFavouritesStationList = () => {
+    if (typeof window === "undefined") {
+        return [];
+    }
+    if (localStorage.getItem(FAVOURITES_STATION_LOCAL_STORAGE_KEY) !== null) {
+        return JSON.parse(localStorage.getItem(FAVOURITES_STATION_LOCAL_STORAGE_KEY)!);
+    }
+
+    return [];
+};
+
+export const storeFavouriteStationsList = (favouriteStations: number[]) => {
+    localStorage.setItem(FAVOURITES_STATION_LOCAL_STORAGE_KEY, JSON.stringify(favouriteStations));
+};
+
+export const getShowFavouriteStations = () => {
+    if (typeof window === "undefined") {
+        return false;
+    }
+    if (localStorage.getItem(SHOW_FAVOURITES_STATION_LOCAL_STORAGE_KEY) !== null) {
+        return JSON.parse(
+            localStorage.getItem(SHOW_FAVOURITES_STATION_LOCAL_STORAGE_KEY)!
+        ) as boolean;
+    }
+
+    return false;
+};
+
+export const storeShowFavouriteStations = (showFavouriteStations: boolean) => {
+    localStorage.setItem(
+        SHOW_FAVOURITES_STATION_LOCAL_STORAGE_KEY,
+        JSON.stringify(showFavouriteStations)
+    );
+};


### PR DESCRIPTION
Implement a new feature that allows the users to store their favourite stations cached in the browser. This solution leverages the localstorage feature since there is no concept of a single user just yet.

Additional notes:
The user can add a station to their feavourite list via the station modal. A new heart icon has been added to support this action as shown below:
![image](https://github.com/user-attachments/assets/cc0c720c-ff97-4dbf-9f73-d41c060687c6)

In case there is at least one station added in the list of favourite stations, then a new toggle becomes visible so the user can filter the stations in the Weather Map and Stations pages. Please see the images below:

WeatherMap page:
_When the toggle is disabled:_
![image](https://github.com/user-attachments/assets/455ea936-2d9f-4797-bcb3-22ff58d1806a)
_When the toggle is enabled:_
![image](https://github.com/user-attachments/assets/3f0bfbc6-0229-49e3-843f-604c1b18c139)

_The search form is being updated dynamically without the need of a page reload to reflect the filter:_
![image](https://github.com/user-attachments/assets/b03d368d-912a-4edd-97e8-f28848b2a733)

Stations page:
_When the toggle is disabled:_
![image](https://github.com/user-attachments/assets/e6108e0b-d2ef-411a-8796-8b0a7bd04dd4)
_When the toggle is enabled:_
![image](https://github.com/user-attachments/assets/f4a59f6b-1002-404a-af89-d6549097c8e3)

The feature works for multiple browsers windows and tabs, however I've kept the solution minimal for now and have not adde any listeners. This means if the user has opened multiple windows/tabs, any changes in one of them will require a page reload in the other to reflect the changes. This could be improved further if required in a future task.
